### PR TITLE
:bug: fix: set final error state for generic error conditions.

### DIFF
--- a/src/components/form/form-two.tsx
+++ b/src/components/form/form-two.tsx
@@ -30,7 +30,7 @@ const FormTwo = (): React.JSX.Element => {
             setFieldErrors({
                 fullName: 'Nome já cadastrado.'
             });
-        } else {
+        } else if (res.message != null) {
             setFormError(true);
         }
         setSubmitted(true);


### PR DESCRIPTION
Error state was set in an else, so it was always set, even when there were no errors (creation of new registry on DB was successful). 

Now (the error state) is not set when there's no error from the server action.